### PR TITLE
Make the upper and lower bounds in `addVar` optional

### DIFF
--- a/include/scippp/model.hpp
+++ b/include/scippp/model.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <optional>
 #include <scip/scip.h>
 #include <string>
 #include <type_traits>
@@ -94,8 +95,8 @@ public:
         const std::string& name,
         SCIP_Real coeff = 0.0,
         VarType varType = VarType::CONTINUOUS,
-        SCIP_Real lb = 0.0,
-        SCIP_Real ub = 1.0);
+        std::optional<double> lb = 0.0,
+        std::optional<double> ub = 1.0);
 
     /**
      * Adds multiple variables to the model.
@@ -116,8 +117,8 @@ public:
         size_t numVars,
         const CoeffType& coeffs = COEFF_ZERO,
         VarType varType = VarType::CONTINUOUS,
-        SCIP_Real lb = 0.0,
-        SCIP_Real ub = 1.0)
+        std::optional<double> lb = 0.0,
+        std::optional<double> ub = 1.0)
     {
         std::vector<Var> result;
         result.reserve(numVars);

--- a/source/model.cpp
+++ b/source/model.cpp
@@ -6,15 +6,15 @@
 
 namespace scippp {
 
-Var& Model::addVar(const std::string& name, SCIP_Real coeff, VarType varType, SCIP_Real lb, SCIP_Real ub)
+Var& Model::addVar(const std::string& name, SCIP_Real coeff, VarType varType, std::optional<double> lb, std::optional<double> ub)
 {
     SCIP_VAR* var { nullptr };
     m_scipCallWrapper(SCIPcreateVarBasic(
         m_scip, /* SCIP environment */
         &var, /* reference to the variable */
         name.c_str(), /* name of the variable */
-        lb, /* lower bound of the variable */
-        ub, /* upper bound of the variable */
+        lb != std::nullopt ? lb.value() : -SCIPinfinity(m_scip), /* lower bound of the variable */
+        ub != std::nullopt ? ub.value() : SCIPinfinity(m_scip), /* upper bound of the variable */
         coeff, /* obj. coefficient. */
         static_cast<SCIP_Vartype>(varType) /* variable is binary */
         ));

--- a/test/test_var.cpp
+++ b/test/test_var.cpp
@@ -1,4 +1,5 @@
 #include <boost/test/unit_test.hpp>
+#include <optional>
 
 #include "scippp/model.hpp"
 #include "scippp/parameters.hpp"
@@ -11,7 +12,7 @@ BOOST_AUTO_TEST_SUITE(Var)
 BOOST_AUTO_TEST_CASE(GetSolVal, *boost::unit_test::tolerance(1e-3))
 {
     Model model("Simple");
-    auto x1 = model.addVar("x_1", 1);
+    auto x1 = model.addVar("x_1", 1, VarType::CONTINUOUS, 0.0, std::nullopt);
     auto x2 = model.addVar("x_2", 1);
     model.addConstr(x1 + x2 >= 1, "capacity");
     model.addConstr(x1 == x2, "equal");


### PR DESCRIPTION
Copying the API of `PySCIPOpt`, if the upper bound or lower bound are specified as `std::nullopt` then they are `-SCIPinfinity` or `SCIPinfinity` respectively