### PR TITLE
Depend on boost>=1.81 when building tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           conan profile detect
           conan profile detect --name debug
           echo "&:build_type=Debug" >> $(conan profile path debug)
-          conan install -of . -pr debug -o with_tests=True .
+          conan install -of . -pr debug -o with_tests=True . --build=missing
       - name: Run CMake
         run: cmake --preset conan-debug -DUSE_COVERAGE=ON .
       - name: Compile
@@ -44,7 +44,7 @@ jobs:
         run: |
           conan profile detect
           powershell -Command "(gc $(conan profile path default)) -replace 'compiler.cppstd=14', 'compiler.cppstd=17' | Out-File -encoding ASCII $(conan profile path default)"
-          conan install -of . -o with_tests=True .
+          conan install -of . -o with_tests=True . --build=missing
       - name: Run CMake
         run: cmake --preset conan-default .
       - name: Compile
@@ -82,7 +82,7 @@ jobs:
       - name: Run Conan Install
         run: |
           conan profile detect
-          conan install -of . -o with_tests=True .
+          conan install -of . -o with_tests=True . --build=missing
       - name: Run CMake
         run: cmake --preset conan-release .
       - name: Compile
@@ -97,7 +97,7 @@ jobs:
       - name: Run Conan Install
         run: |
           conan profile detect
-          conan install -of . .
+          conan install -of . . --build=missing
       - name: Create CMake Compilation Database
         run: cmake --preset conan-release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
       - name: Run Clang-Tidy

--- a/conanfile.py
+++ b/conanfile.py
@@ -61,11 +61,14 @@ class ScipPlusPlus(ConanFile):
 
     def set_version(self):
         if self.version is None:
+            print("No version set from outside")
             git = Git(self, folder=self.recipe_folder)
             try:
                 self.version = git.run("describe --tags --dirty=-d").strip()
+                print(f"Version determined from Git is {self.version}")
             except:
                 self.version = "1.0.2"
+                print(f"Unable to determine version from Git, using {self.version} instead")
 
     def layout(self):
         cmake_layout(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,7 +77,7 @@ class ScipPlusPlus(ConanFile):
     def requirements(self):
         self.requires("scip/8.0.3", transitive_headers=True)
         if self.options.with_tests:
-            self.requires("boost/1.81.0")  # required only for tests
+            self.requires("boost/[>=1.81.0]")  # required only for tests
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,6 @@ class ScipPlusPlus(ConanFile):
         "shared": False,
         "fPIC": True
     }
-    _full_version: str = None
 
     @property
     def _min_cppstd(self):
@@ -64,12 +63,9 @@ class ScipPlusPlus(ConanFile):
         if self.version is None:
             git = Git(self, folder=self.recipe_folder)
             try:
-                self._full_version = git.run("describe --tags --dirty=-d").strip()
-                self.version = self._full_version.split('-')[0]
+                self.version = git.run("describe --tags --dirty=-d").strip()
             except:
                 self.version = "1.0.2"
-        else:
-            self._full_version = self.version
 
     def layout(self):
         cmake_layout(self)
@@ -81,7 +77,7 @@ class ScipPlusPlus(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables[self.name + "_version"] = self._full_version
+        tc.variables[self.name + "_version"] = self.version
         tc.variables["BUILD_TESTS"] = self.options.with_tests
         tc.generate()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -61,14 +61,11 @@ class ScipPlusPlus(ConanFile):
 
     def set_version(self):
         if self.version is None:
-            print("No version set from outside")
             git = Git(self, folder=self.recipe_folder)
             try:
                 self.version = git.run("describe --tags --dirty=-d").strip()
-                print(f"Version determined from Git is {self.version}")
             except:
-                self.version = "1.0.2"
-                print(f"Unable to determine version from Git, using {self.version} instead")
+                self.version = "1.0.x"  # todo: rename before next release
 
     def layout(self):
         cmake_layout(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -72,6 +72,7 @@ class ScipPlusPlus(ConanFile):
 
     def requirements(self):
         self.requires("scip/8.0.3", transitive_headers=True)
+        self.requires("gmp/6.3.0", override=True)  # todo: remove once SCIP 8.0.4 without the conflict is released
         if self.options.with_tests:
             self.requires("boost/[>=1.81.0]")  # required only for tests
 


### PR DESCRIPTION
We should not depend on a specific version of boost as this might be in conflict with the boost version of a dependency