### PR TITLE
Draft: Speedup LinExpr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15.7)
 project(ScipPP LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 option(USE_COVERAGE "Create coverage report." OFF)

--- a/include/scippp/lin_expr.hpp
+++ b/include/scippp/lin_expr.hpp
@@ -46,6 +46,32 @@ public:
      */
     LinExpr(const Var& var);
 
+    LinExpr(const std::initializer_list<Var>& vars)
+        : m_vars { vars.begin(), vars.end() }
+        , m_coeffs(vars.size(), 1)
+    {
+    }
+
+    template <typename Span>
+        requires requires { typename Span::value_type; }
+    LinExpr(const Span& vars)
+        : m_vars { vars.begin(), vars.end() }
+        , m_coeffs(vars.size(), 1)
+    {
+    }
+
+    template <typename VarSpan, typename CoeffSpan>
+        requires requires {
+            typename VarSpan::value_type;
+            typename CoeffSpan::value_type;
+        }
+    LinExpr(const VarSpan& vars, const CoeffSpan& coeffs)
+        : m_vars(vars.begin(), vars.end())
+        , m_coeffs(coeffs.begin(), coeffs.end())
+    {
+        // assert(vars.size() == coeffs.size());
+    }
+
     /**
      * Returns the constant term of the expression.
      * @since 1.0.0

--- a/test/test_linexpr.cpp
+++ b/test/test_linexpr.cpp
@@ -1,0 +1,63 @@
+#include <boost/test/unit_test.hpp>
+
+#include "scippp/model.hpp"
+#include "scippp/solving_statistics.hpp"
+
+using namespace scippp;
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(LinExpression)
+
+BOOST_AUTO_TEST_CASE(AddOneVar)
+{
+    Model model("Simple");
+    array coeff { 1, 1 };
+    const auto& [x1, x2] = model.addVars<2>("x_", coeff);
+    LinExpr l;
+    l += x1; // allocates memory, thus slow
+    l += x2; // allocates memory again, thus slow
+    model.addConstr(l <= 1, "capacity");
+    model.setObjsense(Sense::MAXIMIZE);
+    model.solve();
+    BOOST_TEST(model.getSolvingStatistic(statistics::PRIMALBOUND) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(CtorArray)
+{
+    Model model("Simple");
+    array coeff { 1, 1 };
+    const auto VARS = model.addVars<2>("x_", coeff);
+    LinExpr l(VARS);
+    model.addConstr(l <= 1, "capacity");
+    model.setObjsense(Sense::MAXIMIZE);
+    model.solve();
+    BOOST_TEST(model.getSolvingStatistic(statistics::PRIMALBOUND) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(AddArray)
+{
+    Model model("Simple");
+    array coeff { 1, 1 };
+    const auto VARS = model.addVars<2>("x_", coeff);
+    LinExpr l;
+    l += VARS;
+    model.addConstr(l <= 1, "capacity");
+    model.setObjsense(Sense::MAXIMIZE);
+    model.solve();
+    BOOST_TEST(model.getSolvingStatistic(statistics::PRIMALBOUND) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(AddInitializerList)
+{
+    Model model("Simple");
+    array coeff { 1, 1 };
+    const auto& [x1, x2] = model.addVars<2>("x_", coeff);
+    LinExpr l;
+    l += {x1, x2};
+    model.addConstr(l <= 1, "capacity");
+    model.setObjsense(Sense::MAXIMIZE);
+    model.solve();
+    BOOST_TEST(model.getSolvingStatistic(statistics::PRIMALBOUND) == 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adding multiple variables at once to a linear expression is now faster as we do not allocate new memory for each and every variable individually, but all at once.

This is a draft. In my opinion, the code is a bit ugly